### PR TITLE
Conform to shell best practices

### DIFF
--- a/cabal-install-bin
+++ b/cabal-install-bin
@@ -1,20 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Install binaries via Cabal in an isolated environment.
 
-self=`basename $0`
+self="$(basename "$0")"
 if [ $# -eq 0 ]
 then
-      echo "Usage: $self package(s)"
+      printf "Usage: %s package(s)\n" "$self" >&2
       exit 1
 fi
 
-tmp=`mktemp -d` &&
-echo -n "Created temporary directory" &&
-cd $tmp &&
-echo -n " $tmp"
-
-echo
+tmp="$(mktemp -d)" &&
+printf "Created temporary directory" &&
+cd "$tmp" &&
+printf " %s\n" "$tmp"
 
 {
       cabal sandbox init \
@@ -23,12 +21,12 @@ echo
                     --disable-library-profiling \
                     --disable-shared \
                     --disable-executable-dynamic \
-                    $@ \
+                    "$@" \
       &&
-      mv -i --target-directory=$HOME/.cabal/bin \
+      mv -i --target-directory="$HOME/.cabal/bin" \
             .cabal-sandbox/bin/*
 } || {
-      echo "$self $@: Installation failed!"
+      printf "%s %s: Installation failed!\n" "$self" "$@" >&2
 }
 
-rm -r $tmp && echo "Removed temporary directory $tmp"
+rm -r "$tmp" && printf "Removed temporary directory %s\n" "$tmp"


### PR DESCRIPTION
Hi! I saw this go by on Reddit and noticed some common shell pitfalls. Hope you don't mind my fixing them.

From the commit message:
- Use `/bin/sh` shebang now that we conform to POSIX
- Replace deprecated backticks with $( )
- Replace `echo` with `printf` in cases where options were being used or
  the printed string contained variables. `echo` is not portable in
  these cases.
- Quote all expansions to avoid unwanted word splitting
- Output to `stderr` where appropriate
