### PR TITLE
Cross platform mktemp & prefix instead of bindir

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Cabal     | 1.22.0.0    | cabal-install-1.22.0.0
 GHC Core  | n/a         | ghc-core-0.5.6
 HLint     | 1.9.15      | hlint-1.9.15
 HsColour  | 1.20        | hscolour-1.20.3
+Pandoc    | 1.13.2      | pandoc-1.13.2
 
 ### Unsuccessful
 
@@ -51,4 +52,3 @@ Program   | package name  | Problem
 ----------|---------------|-----------------------------------------------------
 Alex      | alex-3.1.4    | Hardcodes certain paths in executable
 Happy     | happy-1.19.5  | Hardcodes certain paths in executable
-Pandoc    | pandoc-1.13.2 | Requires files in known location for some operations

--- a/cabal-install-bin
+++ b/cabal-install-bin
@@ -29,10 +29,10 @@ cd "$tmp"
 
 
 ###############################################################################
-##  Get bindir  ###############################################################
+##  Get prefix  ###############################################################
 ###############################################################################
 
-bindir="$HOME/.cabal/bin"
+prefix="$HOME/.cabal/"
 
 
 
@@ -47,7 +47,7 @@ bindir="$HOME/.cabal/bin"
                     --disable-library-profiling \
                     --disable-shared \
                     --disable-executable-dynamic \
-                    --bindir="$bindir" \
+                    --prefix="$prefix" \
                     "$@"
 } || {
       printf "%s %s: Installation failed!\n" "$self" "$@" >&2

--- a/cabal-install-bin
+++ b/cabal-install-bin
@@ -22,7 +22,7 @@ fi
 ###############################################################################
 
 printf "Creating temporary directory"
-tmp="$(mktemp -d)"
+tmp="$(mktemp -d 2>/dev/null || mktemp -d -t cabal)"
 printf " (%s)\n" "$tmp"
 cd "$tmp"
 


### PR DESCRIPTION
Using `--prefix` allows more programs to work, f.ex. pandoc works without `-fembed_data_files`.
