### PR TITLE
Add prefix-related improvements

### DIFF
--- a/cabal-install-bin
+++ b/cabal-install-bin
@@ -32,7 +32,7 @@ cd "$tmp"
 ##  Get prefix  ###############################################################
 ###############################################################################
 
-prefix="$HOME/.cabal/"
+prefix="$HOME/.cabal"
 
 
 
@@ -47,8 +47,11 @@ prefix="$HOME/.cabal/"
                     --disable-library-profiling \
                     --disable-shared \
                     --disable-executable-dynamic \
-                    --prefix="$prefix" \
+                    --bindir="$prefix/bin" \
+                    --datadir="$prefix/share" \
                     "$@"
+# do not actually specify --prefix to prevent installation of libraries to
+# "$HOME/.cabal/lib".
 } || {
       printf "%s %s: Installation failed!\n" "$self" "$@" >&2
 }


### PR DESCRIPTION
- Remove trailing "/" from prefix
- Stop installation of lib to $HOME/.cabal, by only specifying
  --bindir and --datadir.

not directly tested, but the equivalent install command works fine in my setup, see https://github.com/lspitzner/cabal-exec-install/blob/master/cabal-exec-install.sh#l73-78, which is tested with all the executables listed in https://github.com/lspitzner/cabal-exec-install/blob/master/cabal-exec-install.sh#l132-155.

have not removed the "works-not-with" section yet.
